### PR TITLE
fix: wire up --cache flag to actually skip unchanged files during schema generation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-runtime-validation",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "author": "Matthew Duong <thegalah@gmail.com>",
     "license": "MIT",
     "dependencies": {

--- a/src/SchemaGenerator.ts
+++ b/src/SchemaGenerator.ts
@@ -1,11 +1,12 @@
 import { ICommandOptions } from "./ICommandOptions";
 import path from "path";
-import { FileDiscovery } from "./services/FileDiscovery";
+import { FileDiscovery, FileInfo } from "./services/FileDiscovery";
 import { SchemaProcessor } from "./services/SchemaProcessor";
 import { CodeGenerator } from "./services/CodeGenerator";
 import { SchemaWriter } from "./services/SchemaWriter";
 import { ProgressReporter } from "./utils/ProgressReporter";
 import { formatError, isKnownError } from "./errors";
+import { Schema } from "ts-json-schema-generator";
 
 const validationSchemaFileName = "validation.schema.json";
 const schemaDefinitionFileName = "SchemaDefinition.ts";
@@ -69,17 +70,51 @@ export class SchemaGenerator {
             // Discover files
             this.progressReporter.update(0, "Discovering files...");
             const files = await this.fileDiscovery.discoverFiles();
-            
+
             if (this.options.verbose) {
                 console.log(`Found ${files.length} schema file(s)`);
                 files.forEach(file => console.log(`  - ${file.path}`));
             }
-            
+
+            // Separate changed and unchanged files when caching is enabled
+            const cacheEnabled = this.options.cache || false;
+            let filesToProcess: FileInfo[];
+            const cachedSchemas = new Map<string, Schema>();
+
+            if (cacheEnabled) {
+                filesToProcess = files.filter(f => f.changed !== false);
+                const unchangedFiles = files.filter(f => f.changed === false);
+                for (const file of unchangedFiles) {
+                    const cached = this.fileDiscovery.getCachedSchema(file.path);
+                    if (cached) {
+                        cachedSchemas.set(file.path, cached as Schema);
+                    } else {
+                        // No cached schema available, must reprocess
+                        filesToProcess.push(file);
+                    }
+                }
+                if (this.options.verbose) {
+                    console.log(`Cache: ${cachedSchemas.size} unchanged, ${filesToProcess.length} to process`);
+                }
+            } else {
+                filesToProcess = files;
+            }
+
             // Process schemas
             this.progressReporter.update(1, "Processing TypeScript files...");
-            this.progressReporter.options.total = files.length + 4; // files + 4 generation steps
-            
-            const schemaMap = await this.schemaProcessor.processFiles(files);
+            this.progressReporter.options.total = filesToProcess.length + 4; // files + 4 generation steps
+
+            const processedSchemas = filesToProcess.length > 0
+                ? await this.schemaProcessor.processFiles(filesToProcess)
+                : new Map<string, Schema>();
+
+            // Merge processed and cached schemas
+            const schemaMap = new Map<string, Schema>([...cachedSchemas, ...processedSchemas]);
+
+            // Save all schemas to cache for next run
+            if (cacheEnabled) {
+                await this.fileDiscovery.saveSchemasToCache(schemaMap);
+            }
             
             if (schemaMap.size === 0) {
                 console.log("No types found to generate schemas for");

--- a/src/services/FileDiscovery.ts
+++ b/src/services/FileDiscovery.ts
@@ -16,17 +16,19 @@ export interface FileInfo {
     path: string;
     hash?: string;
     lastModified?: Date;
+    changed?: boolean;
 }
 
 export class FileDiscovery {
     private cacheFile: string;
+    private schemaCacheFile: string;
     private fileCache: Map<string, string> = new Map();
+    private schemaCache: Map<string, object> = new Map();
 
     constructor(private options: FileDiscoveryOptions) {
-        this.cacheFile = path.join(
-            options.cachePath || ".ts-runtime-validation-cache",
-            "file-hashes.json"
-        );
+        const cacheDir = options.cachePath || ".ts-runtime-validation-cache";
+        this.cacheFile = path.join(cacheDir, "file-hashes.json");
+        this.schemaCacheFile = path.join(cacheDir, "schema-cache.json");
         if (options.cacheEnabled) {
             this.loadCache();
         }
@@ -75,14 +77,16 @@ export class FileDiscovery {
             files.map(async (filePath) => {
                 const stats = await fs.promises.stat(filePath);
                 const hash = await this.getFileHash(filePath);
+                const cachedHash = this.fileCache.get(filePath);
                 return {
                     path: filePath,
                     hash,
-                    lastModified: stats.mtime
+                    lastModified: stats.mtime,
+                    changed: cachedHash !== hash
                 };
             })
         );
-        
+
         await this.saveCache(enrichedFiles);
         return enrichedFiles;
     }
@@ -97,6 +101,23 @@ export class FileDiscovery {
         return cachedHash !== currentHash;
     }
 
+    public getCachedSchema(filePath: string): object | undefined {
+        return this.schemaCache.get(filePath);
+    }
+
+    public async saveSchemasToCache(schemas: Map<string, object>): Promise<void> {
+        const cacheDir = path.dirname(this.schemaCacheFile);
+        if (!fs.existsSync(cacheDir)) {
+            await fs.promises.mkdir(cacheDir, { recursive: true });
+        }
+        const data: Record<string, object> = {};
+        for (const [key, value] of schemas) {
+            data[key] = value;
+            this.schemaCache.set(key, value);
+        }
+        await fs.promises.writeFile(this.schemaCacheFile, JSON.stringify(data));
+    }
+
     private loadCache(): void {
         try {
             if (fs.existsSync(this.cacheFile)) {
@@ -105,9 +126,16 @@ export class FileDiscovery {
                 );
                 this.fileCache = new Map(Object.entries(cacheData));
             }
+            if (fs.existsSync(this.schemaCacheFile)) {
+                const schemaData = JSON.parse(
+                    fs.readFileSync(this.schemaCacheFile, 'utf-8')
+                );
+                this.schemaCache = new Map(Object.entries(schemaData));
+            }
         } catch (error) {
             console.warn('Failed to load cache, starting fresh');
             this.fileCache.clear();
+            this.schemaCache.clear();
         }
     }
 
@@ -133,8 +161,12 @@ export class FileDiscovery {
 
     public clearCache(): void {
         this.fileCache.clear();
+        this.schemaCache.clear();
         if (fs.existsSync(this.cacheFile)) {
             fs.unlinkSync(this.cacheFile);
+        }
+        if (fs.existsSync(this.schemaCacheFile)) {
+            fs.unlinkSync(this.schemaCacheFile);
         }
     }
 }


### PR DESCRIPTION
  - Fixed --cache flag which was a no-op — file hashes were computed and stored but never used to skip unchanged files                                                                                                                                        
  - Added changed field to FileInfo to track whether files differ from cached hashes                                                                                                                                                                          
  - Added per-file schema caching (schema-cache.json) so unchanged files reuse prior results instead of regenerating                                                                                                                                          
  - Wired up cache logic in SchemaGenerator to filter unchanged files and merge cached + freshly processed schemas                                                                                                                                            
  - Added verbose logging for cache hits/misses (Cache: N unchanged, M to process)   